### PR TITLE
Add auto-resizing functionality and Ctrl+Enter support to message input

### DIFF
--- a/media/inputContainer.js
+++ b/media/inputContainer.js
@@ -5,11 +5,16 @@ function initInputContainer() {
     const sendButton = document.getElementById('send-button');
 
     messageInput.addEventListener('keypress', function (e) {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            const message = messageInput.value.trim();
-            if (message !== '') {
-                sendButton.click();
+        if (e.key === 'Enter') {
+            if (e.ctrlKey) {
+                e.preventDefault();
+                const message = messageInput.value.trim();
+                if (message !== '') {
+                    sendButton.click();
+                }
+            } else if (!e.shiftKey) {
+                e.preventDefault();
+                messageInput.setRangeText('\n', messageInput.selectionStart, messageInput.selectionEnd, 'end');
             }
         }
     });
@@ -19,10 +24,10 @@ function initInputContainer() {
         if (message) {
             // Add the user's message to the chat UI
             addMessageToUI('user', message);
-    
+
             // Clear the input field
             messageInput.value = '';
-    
+
             // Process and send the message to the extension
             messageUtil.sendMessage({
                 command: 'sendMessage',

--- a/media/inputContainer.js
+++ b/media/inputContainer.js
@@ -1,4 +1,20 @@
 
+const messageInput = document.getElementById('message-input');
+const inputContainer = document.getElementById('input-container');
+
+const defaultHeight = 16;
+
+function autoResizeTextarea() {
+    const lineCount = (messageInput.value.match(/\n/g) || []).length + 1;
+    messageInput.style.height = 'auto';
+    messageInput.style.height = (lineCount <= 1 ? defaultHeight : messageInput.scrollHeight) + 'px';
+    inputContainer.style.height = 'auto';
+    inputContainer.style.height = messageInput.style.height + 25;
+}
+
+messageInput.addEventListener('input', autoResizeTextarea);
+
+autoResizeTextarea();
 
 function initInputContainer() {
     const messageInput = document.getElementById('message-input');
@@ -15,6 +31,7 @@ function initInputContainer() {
             } else if (!e.shiftKey) {
                 e.preventDefault();
                 messageInput.setRangeText('\n', messageInput.selectionStart, messageInput.selectionEnd, 'end');
+                autoResizeTextarea();
             }
         }
     });
@@ -33,6 +50,7 @@ function initInputContainer() {
                 command: 'sendMessage',
                 text: message
             });
+            autoResizeTextarea();
         }
     });
 


### PR DESCRIPTION
## Description

This pull request adds two new features to the project:

1. **Auto-resizing message input:** With this feature, the message input field will automatically resize based on the number of lines of text entered. Additionally, the input container will also resize accordingly. This has been implemented by introducing a new function called `autoResizeTextarea()`, which is called on input and sets the height of the message input and input container based on the number of lines of text entered. The default height is set to 16.

2. **Support for sending messages with Ctrl+Enter:** With this feature, users can now send messages by pressing Ctrl+Enter instead of having to press Enter and then remove the new line. If the user presses Enter without Ctrl or Shift, a new line is added to the input field. The `initInputContainer()` function has been modified to support this functionality. Additionally, unnecessary whitespace has been removed from the code.

Overall, these features will enhance the usability of the project and provide a better user experience.

Please review and merge these changes as appropriate.

Thank you!
