### PR TITLE
Add error logging to DevChat child process

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -69,6 +69,11 @@ class DevChat {
 			});
 	
 			this.childProcess.on('close', (code: number) => {
+				if (stderr) {
+					logger.channel()?.error(stderr);
+					logger.channel()?.show();
+				}
+
 				if (code === 0) {
 					resolve({ code, stdout, stderr });
 				} else {


### PR DESCRIPTION
- Check for stderr in the 'close' event
- Log the error to the logger channel
- Show the logger channel if an error occurs