### PR TITLE
Add CircleCI Configuration For Automated Build And Publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2.1
+executors:
+  node-executor:
+    docker:
+      - image: cimg/node:14.15
+jobs:
+  build:
+    executor: node-executor
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  publish:
+    executor: node-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Update version in package.json"
+          command: |
+            sed -i "s/\"version\": \".*\",/\"version\": \"${CIRCLE_TAG:1}\",/" package.json
+      - run:
+          name: "Publish to Marketplace"
+          command: npx vsce publish -p $VSCE_TOKEN
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: main
+      - publish:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ You can configure the following settings in your `settings.json` file:
 
 If you have any suggestions or issues, please feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/covespace/devchat-vscode.git).
 
+## Automated Publishing Process
+
+Check out our [Automated Publishing Process](./docs/publish.md) for a detailed walkthrough of how we manage the automated release of new versions for the DevChat VSCode Extension.
+
 ## License
 
 *Specify the license here*

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,0 +1,28 @@
+# Automated Publishing Process for DevChat VSCode Extension
+
+This document aims to explain the automated publishing process for our DevChat VSCode Extension.
+We use CircleCI for continuous integration and deployment to streamline the development and release process.
+
+## Tagging Triggers Publishing
+
+Every time we are ready to publish a new version of the extension, we create a Git tag on the main branch.
+The tag's format is vX.X.X (e.g., v1.2.3).
+
+CircleCI is set up to listen for new tags on the main branch. When a new tag is created,
+it triggers the publishing workflow, which consists of building the extension and then publishing it to the VSCode Marketplace.
+
+## Tag Number as Version Number
+
+The number part of the Git tag (omitting the v prefix) is used as the version number for the extension.
+During the publishing process, we automatically update the version field in package.json with this number.
+
+For example, if the Git tag is v1.2.3, the version number used in package.json will be 1.2.3.
+
+This automation ensures consistency between the Git tags and the published version numbers,
+making it easier to manage and track versions.
+
+## Conclusion
+
+Our CircleCI-based publishing process enables a smooth, automated workflow for releasing new versions of the DevChat VSCode Extension.
+By using Git tags to trigger releases and denote version numbers, we ensure reliable,
+trackable releases that are straightforward for both the development team and the end-users to understand.


### PR DESCRIPTION
This commit introduces a CircleCI configuration that enables automatic building of the VSCode extension on every main branch update. It also sets up automatic publishing to the VSCode Marketplace whenever a new tag is created on the main branch. This workflow significantly improves the CI/CD process of the extension development.