### PR TITLE
Improve secretStorage usage and pipx installation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,7 @@ function activate(context: vscode.ExtensionContext) {
 		const versionOld = await secretStorage.get("devchat_version_old");
 		const versionNew = extensionVersion;
 		const versionChanged = versionOld !== versionNew;
-		secretStorage.store("devchat_version_old", versionNew!);
+		await secretStorage.store("devchat_version_old", versionNew!);
 
 		// status item has three status type
 		// 1. not in a folder
@@ -217,7 +217,7 @@ function activate(context: vscode.ExtensionContext) {
 		if (devchatStatus !== 'ready') {
 			statusBarItem.text = `$(warning)DevChat`;
 			statusBarItem.tooltip = `${devchatStatus}`;
-			statusBarItem.command = '';
+			statusBarItem.command = undefined;
 			// set statusBarItem warning color
 			return;
 		}

--- a/tools/install.py
+++ b/tools/install.py
@@ -12,7 +12,7 @@ def check_pipx_installed():
 def install_pipx():
     print("Installing pipx...")
     try:
-        subprocess.run(["python3", "-m", "pip", "install", "pipx"], check=True)
+        subprocess.run(["python3", "-m", "pip", "install", "pipx", "--force"], check=True)
         print("pipx installed successfully.")
     except subprocess.CalledProcessError as e:
         print("Error installing pipx:", e, file=sys.stderr)


### PR DESCRIPTION
- Add await keyword to secretStorage.store call in extension.ts.
- Set statusBarItem.command to undefined instead of an empty string.
- Force pipx installation in install.py by adding --force flag.