### PR TITLE
Improve handling of partial chat responses and topic creation

### DIFF
--- a/src/handler/sendMessage.ts
+++ b/src/handler/sendMessage.ts
@@ -112,8 +112,10 @@ export async function sendMessage(message: any, panel: vscode.WebviewPanel|vscod
 		chatOptions.reference = parsedMessage.reference;
 	}
 
+	let partialDataText = '';
 	const onData = (partialResponse: ChatResponse) => {
 		const responseText = partialResponse.response.replace(/```\ncommitmsg/g, "```commitmsg");
+		partialDataText = responseText;
 		MessageHandler.sendMessage(panel, { command: 'receiveMessagePartial', text: responseText, user: partialResponse.user, date: partialResponse.date }, false);
 	};
 
@@ -138,6 +140,9 @@ export async function sendMessage(message: any, panel: vscode.WebviewPanel|vscod
 		if (responseText.indexOf('Exit code: undefined') >= 0) {
 			return;
 		}
+	}
+	if (chatResponse.isError) {
+		responseText = partialDataText + responseText;
 	}
 
 	MessageHandler.sendMessage(panel, { command: 'receiveMessage', text: responseText, hash: chatResponse['prompt-hash'], user: chatResponse.user, date: chatResponse.date, isError: chatResponse.isError });

--- a/src/topic/topicManager.ts
+++ b/src/topic/topicManager.ts
@@ -83,7 +83,7 @@ export class TopicManager {
 		const topic = new Topic();
 		this._topics[topic.topicId] = topic;
 		this._notifyCreateTopicListeners(topic);
-		this.setCurrentTopic(topic.topicId);
+		//this.setCurrentTopic(topic.topicId);
 		return topic;
 	}
 


### PR DESCRIPTION
- Store partial chat response data in a separate variable.
- Concatenate partial data with responseText when chatResponse.isError is true.
- Comment out setCurrentTopic call in topicManager.ts.