### PR TITLE
Add args property to Command interface and update regCommandList

### DIFF
--- a/src/command/commandManager.ts
+++ b/src/command/commandManager.ts
@@ -4,6 +4,7 @@ export interface Command {
 	name: string;
 	pattern: string;
 	description: string;
+	args: number;
 	handler: (commandName: string, userInput: string) => Promise<string>;
 }
 
@@ -35,6 +36,7 @@ class CommandManager {
 				name: command.name,
 				pattern: command.pattern,
 				description: command.description,
+				args: command.args,
 				handler: async (commandName: string, userInput: string) => {
 					return CustomCommands.getInstance().handleCommand(commandName, userInput);
 				}

--- a/src/command/customCommand.ts
+++ b/src/command/customCommand.ts
@@ -9,6 +9,7 @@ export interface Command {
 	message: string;
 	default: boolean;
 	show: boolean;
+	args: number;
 	instructions: string[];
 }
 
@@ -51,6 +52,7 @@ class CustomCommands {
 								description: settings.description,
 								message: settings.message,
 								default: settings.default,
+								args: settings.args === undefined ? 0 : settings.args,
 								show: settings.show === undefined ? "true" : settings.show,
 								instructions: settings.instructions.map((instruction: string) => path.join(commandDir, commandSubDir, instruction))
 							};

--- a/src/handler/regCommandList.ts
+++ b/src/handler/regCommandList.ts
@@ -8,7 +8,16 @@ regInMessage({command: 'regCommandList'});
 regOutMessage({command: 'regCommandList', result: [{name: '', pattern: '', description: ''}]});
 export async function regCommandList(message: any, panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {
 	const commandList = CommandManager.getInstance().getCommandList();
-	MessageHandler.sendMessage(panel, { command: 'regCommandList', result: commandList });
+	const commandCovertedList = commandList.map(command => {
+		if (command.args > 0) {
+			// replace {{prompt}} with {{["",""]}}, count of "" is args
+			const prompt = Array.from({length: command.args}, () => "");
+			command.pattern = command.pattern.replace('{{prompt}}', '{{' + JSON.stringify(prompt) + '}}');
+		}
+		return command;
+	});
+
+	MessageHandler.sendMessage(panel, { command: 'regCommandList', result: commandCovertedList });
 	return;
 }
 


### PR DESCRIPTION
- Added args property to Command interface in commandManager.ts and customCommand.ts.
- Updated regCommandList handler to convert command patterns with args.
- Replaced {{prompt}} with an array of empty strings based on the args count.