### PR TITLE
Add double dash to DevChat arguments

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -145,6 +145,7 @@ class DevChat {
 
 	async chat(content: string, options: ChatOptions = {}, onData: (data: ChatResponse) => void): Promise<ChatResponse> {
 		const args = await this.buildArgs(options);
+		args.push("--");
 		args.push(content);
 
 		const workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();


### PR DESCRIPTION
- Update devchat.ts to include a double dash in the chat() method.
- Ensure proper separation of options and content in the chat() method.